### PR TITLE
Remove `aoeu` line in create all data script

### DIFF
--- a/scripts/create_all_data.sh
+++ b/scripts/create_all_data.sh
@@ -19,7 +19,6 @@ echo
 if [ -e "data/raw/dcs" ]; then
     echo "Training data already exists -- skipping fetch."
 else
-    aoeu
     echo "Training data does not exist -- fetching."
     mkdir -p "data/raw/dcs"
     git clone --depth 1 https://github.com/OliverHellwig/sanskrit.git dcs-data


### PR DESCRIPTION
Fix issue #48 by removing [the stray dummy line ](https://github.com/ambuda-org/vidyut/blob/c853bfd4009a545e7579160e3666c1775fd32518/scripts/create_all_data.sh#L22) of  `create_all_data.sh` script.
