### PR TITLE
[prakriya] Fix prakriya for `akzRnoti` and others

### DIFF
--- a/vidyut-prakriya/src/tripadi/pada_8_4.rs
+++ b/vidyut-prakriya/src/tripadi/pada_8_4.rs
@@ -200,7 +200,14 @@ fn try_natva_for_span(p: &mut Prakriya, text: &str, i_rs: usize, i_n: usize) -> 
         let is_exempt_pratipadika = p.has(i_x, |t| t.starts_with("srOGn"));
         if is_samana_pada && !is_exempt_pratipadika {
             // TODO: track loctaion of rzfF for better rule logging.
-            p.run("8.4.2", |p| p.set_char_at(i_n, "R"));
+
+            if i_rs + 1 == i_n {
+                // When R immediately follows r/z
+                p.run("8.4.1", |p| p.set_char_at(i_n, "R"));
+            } else {
+                // When r/z and R are intervened by at, ku, etc.
+                p.run("8.4.2", |p| p.set_char_at(i_n, "R"));
+            }
         } else if x.has_text_in(&["grAma", "agra"]) && y.has_u("RI\\Y") {
             // See Kashika on 3.2.61 and SK 2975.
             p.run(Rule::Kaumudi("2975"), |p| p.set_char_at(i_n, "R"));

--- a/vidyut-prakriya/tests/prakriyas.rs
+++ b/vidyut-prakriya/tests/prakriyas.rs
@@ -8,7 +8,7 @@ use vidyut_prakriya::args::*;
 use vidyut_prakriya::Rule;
 
 #[test]
-fn bhavadi() {
+fn bhavati() {
     let bhu = d("BU", Bhvadi);
     let args = Tinanta::builder()
         .dhatu(bhu)
@@ -34,4 +34,46 @@ fn bhavadi() {
             (A("6.1.78"), vec!["Bav", "a", "ti"]),
         ],
     );
+}
+
+// Test to make sure 8.4.1 applies in akzRoti (i.e when R immediately follows r/z)
+#[test]
+fn akshnoti() {
+    let akz = d("akzU~", Bhvadi);
+    let args = Tinanta::builder()
+        .dhatu(akz)
+        .prayoga(Prayoga::Kartari)
+        .purusha(Purusha::Prathama)
+        .vacana(Vacana::Eka)
+        .lakara(Lakara::Lat)
+        .build()
+        .unwrap();
+    let t = Tester::default();
+    let ps = t.derive_tinantas(&args);
+    let p = ps.iter().find(|p| p.text() == "akzRoti").unwrap();
+
+    use Rule::Ashtadhyayi as A;
+
+    assert_matches_prakriya(p, &[(A("8.4.1"), vec!["ak", "Ro", "ti"])]);
+}
+
+// Test to make sure 8.4.2 applies in when r/z and R are intervened by at, ku, etc.
+#[test]
+fn krinaati() {
+    let krii = d("qukrI\\Y", Kryadi);
+    let args = Tinanta::builder()
+        .dhatu(krii)
+        .prayoga(Prayoga::Kartari)
+        .purusha(Purusha::Prathama)
+        .vacana(Vacana::Eka)
+        .lakara(Lakara::Lat)
+        .build()
+        .unwrap();
+    let t = Tester::default();
+    let ps = t.derive_tinantas(&args);
+    let p = ps.iter().find(|p| p.text() == "krIRAti").unwrap();
+
+    use Rule::Ashtadhyayi as A;
+
+    assert_matches_prakriya(p, &[(A("8.4.2"), vec!["krI", "RA", "ti"])]);
 }


### PR DESCRIPTION
With this fix, we correctly apply 8.4.1 for the derivation of `akzRnoti` (`akzU~`) and others.

Fixes #123.