### PR TITLE
Removed lazy_static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,6 @@ version = "0.1.0"
 dependencies = [
  "csv",
  "glob",
- "lazy_static",
  "multimap",
  "vidyut-chandas",
  "vidyut-cheda",
@@ -1805,7 +1804,6 @@ name = "vidyut-chandas"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "lazy_static",
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
@@ -1819,7 +1817,6 @@ dependencies = [
  "clap",
  "compact_str 0.8.1",
  "env_logger",
- "lazy_static",
  "log",
  "priority-queue",
  "regex",
@@ -1891,7 +1888,6 @@ dependencies = [
  "csv",
  "enumset",
  "flate2",
- "lazy_static",
  "rayon",
  "rmp-serde",
  "rustc-hash",
@@ -1924,7 +1920,6 @@ dependencies = [
  "clap",
  "compact_str 0.7.1",
  "csv",
- "lazy_static",
  "rustc-hash",
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ vidyut-prakriya = { path = "./vidyut-prakriya" }
 vidyut-sandhi = { path = "./vidyut-sandhi" }
 csv = "1.1.6"
 multimap = "0.8.3"
-lazy_static = "1.4.0"
 glob = "0.3.1"
 
 [workspace.dependencies]

--- a/bindings-python/Cargo.lock
+++ b/bindings-python/Cargo.lock
@@ -727,7 +727,6 @@ name = "vidyut-chandas"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "lazy_static",
  "serde",
  "serde-wasm-bindgen",
  "serde_derive",
@@ -811,7 +810,6 @@ dependencies = [
  "clap",
  "compact_str 0.7.1",
  "csv",
- "lazy_static",
  "rustc-hash",
 ]
 

--- a/vidyut-chandas/Cargo.toml
+++ b/vidyut-chandas/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-lazy_static = "1.4.0"
 serde = { version = "1.0.150", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 serde_derive = "1.0.193"

--- a/vidyut-chandas/src/sounds.rs
+++ b/vidyut-chandas/src/sounds.rs
@@ -1,10 +1,8 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref HRASVA: Set = Set::from("aiufx");
-    static ref AC: Set = Set::from("aAiIuUfFxXeEoO");
-    static ref HAL: Set = Set::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL");
-}
+static HRASVA: LazyLock<Set> = LazyLock::new(|| Set::from("aiufx"));
+static AC: LazyLock<Set> = LazyLock::new(|| Set::from("aAiIuUfFxXeEoO"));
+static HAL: LazyLock<Set> = LazyLock::new(|| Set::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL"));
 
 type Sound = char;
 

--- a/vidyut-cheda/Cargo.toml
+++ b/vidyut-cheda/Cargo.toml
@@ -13,7 +13,6 @@ compact_str = "0.8.1"
 clap = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
-lazy_static = "1.5.0"
 regex = "1.11.1"
 rmp-serde = { workspace = true }
 serde = {workspace = true }

--- a/vidyut-cheda/src/normalize_text.rs
+++ b/vidyut-cheda/src/normalize_text.rs
@@ -1,4 +1,5 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 /// Creates a normalized version of `text` that is easier to process.
@@ -8,10 +9,8 @@ use regex::Regex;
 /// 2. Delete all whitespace spans.
 /// 3. Separate all remaining spans with a single " ".
 pub fn normalize(text: &str) -> String {
-    lazy_static! {
-        static ref RE: Regex =
-            Regex::new(r"([a-zA-Z']+)|(\s+)|([^a-zA-Z']+)").expect("always defined");
-    }
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"([a-zA-Z']+)|(\s+)|([^a-zA-Z']+)").expect("always defined"));
 
     let mut ret = RE
         .find_iter(text)

--- a/vidyut-cheda/src/sounds.rs
+++ b/vidyut-cheda/src/sounds.rs
@@ -1,6 +1,6 @@
 //! Utility functions for checking Sanskrit sounds.
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 /// A set of Sanskrit sounds.
 ///
@@ -42,10 +42,8 @@ impl Default for SoundSet {
 /// - other punctuation characters (|, ||, numbers)
 /// - characters or symbols from non-SLP1 encodings
 pub fn is_sanskrit(c: char) -> bool {
-    lazy_static! {
-        static ref CHARS: SoundSet =
-            SoundSet::from("aAiIuUfFxXeEoOMHkKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL'");
-    }
+    static CHARS: LazyLock<SoundSet> =
+        LazyLock::new(|| SoundSet::from("aAiIuUfFxXeEoOMHkKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL'"));
     CHARS.contains(c)
 }
 
@@ -53,9 +51,7 @@ pub fn is_sanskrit(c: char) -> bool {
 ///
 /// `ac` is the Paninian name for the Sanskrit vowels.
 pub fn is_ac(c: char) -> bool {
-    lazy_static! {
-        static ref AC: SoundSet = SoundSet::from("aAiIuUfFxXeEoO");
-    }
+    static AC: LazyLock<SoundSet> = LazyLock::new(|| SoundSet::from("aAiIuUfFxXeEoO"));
     AC.contains(c)
 }
 
@@ -64,18 +60,16 @@ pub fn is_ac(c: char) -> bool {
 /// `hal` is the Paninian name for the Sanskrit consonants.
 #[allow(unused)]
 pub fn is_hal(c: char) -> bool {
-    lazy_static! {
-        static ref HAL: SoundSet = SoundSet::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL");
-    }
+    static HAL: LazyLock<SoundSet> =
+        LazyLock::new(|| SoundSet::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL"));
     HAL.contains(c)
 }
 
 /// Returns whether the given sound is voiced.
 #[allow(unused)]
 pub fn is_ghosha(c: char) -> bool {
-    lazy_static! {
-        static ref GHOSHA: SoundSet = SoundSet::from("aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh");
-    }
+    static GHOSHA: LazyLock<SoundSet> =
+        LazyLock::new(|| SoundSet::from("aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh"));
     GHOSHA.contains(c)
 }
 

--- a/vidyut-prakriya/ARCHITECTURE.md
+++ b/vidyut-prakriya/ARCHITECTURE.md
@@ -8,7 +8,6 @@ our system.
 This document assumes some familiarity with basic Rust concepts like structs,
 enums, closures, and lifetimes.
 
-
 Goals and values
 ----------------
 
@@ -40,7 +39,6 @@ than wait for perfect clarity. Fortunately, we have found that as the program
 has grown and matured, we have become more and more able to remove hacks and
 solve problems in a more fundamental way.
 
-
 Core data types
 ---------------
 
@@ -66,20 +64,17 @@ In addition to these three types, we recommend exploring the types in the
 part of its API. Our hope is that callers can lean on Rust's type system to
 define meaningful requests and receive correct derivations.
 
-
 Core modules
 ------------
 
 We start our description here with the high-level `vyakarana` module then work
 our way into specific implementation details.
 
-
 ### `vyakarana`
 
 This defines the public API. Given certain input conditions, the method here
 return all `Prakriya`s compatible with those conditions. `vyakarana` is a thin
 wrapper over the `ashtadhyayi` module, which we describe below.
-
 
 ### `args`
 
@@ -88,8 +83,6 @@ Paninian categories as closely as possible, so we have types like `Dhatu`,
 `Krdanta`, `Subanta`, and so on. Likewise, the type system enforces that
 arguments are well formed. For example, a `Krdanta` must have a `Dhatu` and a
 `Krt`.
-
-
 
 ### `ashtadhyayi`
 
@@ -118,7 +111,6 @@ their own modules. Some examples:
 - `unadipatha`, which defines the rules of the Unadipatha. These rules enter
   the Ashtadhyayi through rule 3.3.1 (*uṇādayo bahulam*)
 
-
 ### `prakriya`, `terms`, and `tags`
 
 These define the `Prakriya` and `Term` types, as well as some useful secondary
@@ -130,7 +122,6 @@ variety of ad-hoc flags.
 
 Since `Term` and `Tag` are not stable, we do not expose them in our public API.
 
-
 ### `prakriya_stack`
 
 This module defines utilities for exploring different paths of optional rules.
@@ -138,12 +129,10 @@ The core type here is `PrakriyaStack`, which manages a stack of rule paths.
 (`RulePathStack` might be a clearer name, but it doesn't quite roll off the
 tongue!)
 
-
 ### `sounds`
 
 This defines various functions for testing and modifying Sanskrit sounds. The
 core data structure here is `Set`, which stores sounds in a simple array.
-
 
 Code style
 ----------
@@ -164,7 +153,6 @@ Our code routinely uses short variable names to reduce visual noise and make
 the logic of each rule more obvious. Here, `p` is a `Prakriya`, `i` is the
 index of some `Term` within the `Prakriya`, and `|t| ...` is a closure (inline
 function) that accepts a `Term`.
-
 
 ### Closures
 
@@ -188,7 +176,6 @@ for `p.terms[i]`. `Prakriya` also defines many methods for working with
     indices, such as `find_first_where`, `find_last_where`, `find_next_where`,
     and so on.
 
-
 ### Naming conventions
 
 Since we have so many rules to write, we use short variable names for common
@@ -202,7 +189,6 @@ concepts. Some examples:
 
 [rust-borrow]: https://users.rust-lang.org/t/newbie-mut-with-nested-structs/84755
 [rust-q]: https://doc.rust-lang.org/rust-by-example/std/result/question_mark.html
-
 
 Control flow
 ------------
@@ -226,7 +212,6 @@ directly encodes a critical principle of the grammar.
 The sections below extend the example above and illustrate the various kinds of
 control flow we use, ordered from least to most complex.
 
-
 ### Rule sequences
 
 The control flow in the example above is appropriate for simple sequences of
@@ -240,7 +225,6 @@ if condition_2 {
     p.run_at("rule_2", i, |t| t.do_something_2());
 }
 ```
-
 
 ### Simple rule blocking
 
@@ -256,7 +240,6 @@ if condition_1 {
     p.run_at("rule_3", i, |t| t.do_something_2());
 }
 ```
-
 
 ### Falling through
 
@@ -276,7 +259,6 @@ if condition_2 {
 ```
 
 Here, `rule_2` is accessible even if we reject `rule_1`.
-
 
 ### Simple locking
 
@@ -299,7 +281,6 @@ if done {
     p.run_at("rule_3", i, |t| t.do_something_2());
 }
 ```
-
 
 ### Extended locking
 
@@ -345,7 +326,6 @@ If we use the new `do_something_1` and `do_something_2` methods here,
 the original `Prakriya` struct, we can access it through `lp.p`. Once the
 lifetime of `lp` has ended, we can continue using `p` as before.
 
-
 ### Context-aware locking
 
 Suppose we wish to derive a *taddhitānta* that uses a specific
@@ -353,4 +333,3 @@ taddhita-pratyaya only if available in a specific meaning context. In this
 case, we can extend the `LockingPrakriya` pattern above to record other useful
 metadata, such as the meaning condition we wish to derive (if any). For
 examples of this pattern, see `KrtPrakriya` and `TaddhitaPrakriya`.
-

--- a/vidyut-prakriya/Cargo.lock
+++ b/vidyut-prakriya/Cargo.lock
@@ -542,7 +542,6 @@ dependencies = [
  "compact_str",
  "csv",
  "enumset",
- "lazy_static",
  "serde",
  "sha2 0.10.6",
  "sha256",

--- a/vidyut-prakriya/Cargo.toml
+++ b/vidyut-prakriya/Cargo.toml
@@ -13,10 +13,9 @@ rust-version = "1.68"
 
 [dependencies]
 enumset = { version = "1.1.3", features = ["serde"] }
-lazy_static = "1.4.0"
 rustc-hash = { workspace = true }
 serde = { version = "1.0.150", features = ["derive"] }
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"]}
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 serde-wasm-bindgen = "0.4"
 console_error_panic_hook = "0.1.7"
 

--- a/vidyut-prakriya/src/angasya/abhyasasya.rs
+++ b/vidyut-prakriya/src/angasya/abhyasasya.rs
@@ -6,6 +6,8 @@ abhyasasya
 Runs rules that modify the abhyāsa.
 */
 
+use std::sync::LazyLock;
+
 use crate::args::Agama as A;
 use crate::args::Agama;
 use crate::args::Aupadeshika;
@@ -23,7 +25,6 @@ use crate::dhatu_gana as gana;
 use crate::it_samjna;
 use crate::sounds as al;
 use crate::sounds::{map, s, Map, Set, AC, HAL};
-use lazy_static::lazy_static;
 
 const AA: Set = s(&["a"]);
 const ANUNASIKA: Set = s(&["Yam"]);
@@ -33,9 +34,7 @@ const KHAY: Set = s(&["Kay"]);
 const F_HAL: Set = s(&["f hal"]);
 const PU_YAN_J: Set = s(&["pu~", "yaR", "j"]);
 
-lazy_static! {
-    static ref KUH_CU: Map = map("ku~ h", "cu~");
-}
+static KUH_CU: LazyLock<Map> = LazyLock::new(|| map("ku~ h", "cu~"));
 
 /// Simplifies the abhyasa per 7.4.60.
 fn try_haladi(text: &str) -> TermString {

--- a/vidyut-prakriya/src/krt/basic.rs
+++ b/vidyut-prakriya/src/krt/basic.rs
@@ -70,15 +70,13 @@ use crate::krt::utils::KrtPrakriya;
 use crate::sounds::{s, Set, AC, HAL, IK};
 use crate::stem_gana::TYAD_ADI;
 use crate::Rule::Varttika;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 const II: Set = s(&["i"]);
 const UU: Set = s(&["u"]);
 const PU: Set = s(&["pu~"]);
 
-lazy_static! {
-    static ref EMPTY_TERM: Term = Term::make_text("");
-}
+static EMPTY_TERM: LazyLock<Term> = LazyLock::new(|| Term::make_text(""));
 
 /// Tries to add various pratyayas that are just "a."
 fn try_add_various_pratyayas(kp: &mut KrtPrakriya) {

--- a/vidyut-prakriya/src/sounds.rs
+++ b/vidyut-prakriya/src/sounds.rs
@@ -34,9 +34,8 @@ We chose SLP1 over something like [WX][wx] merely because we have more familiari
 [slp1]: https://en.wikipedia.org/wiki/SLP1
 [wx]: https://en.wikipedia.org/wiki/WX_notation
 */
-use lazy_static::lazy_static;
 use rustc_hash::FxHashMap;
-use std::fmt;
+use std::{fmt, sync::LazyLock};
 
 type Sound = char;
 
@@ -49,9 +48,7 @@ pub const HAL: Set = s(&["hal"]);
 pub const YAN: Set = s(&["yaR"]);
 pub const VAL: Set = s(&["val"]);
 
-lazy_static! {
-    static ref SOUND_PROPS: FxHashMap<Sound, Uccarana> = create_sound_props();
-}
+static SOUND_PROPS: LazyLock<FxHashMap<Sound, Uccarana>> = LazyLock::new(create_sound_props);
 
 /// A set of Sanskrit sounds.
 ///

--- a/vidyut-prakriya/src/tripadi/pada_8_2.rs
+++ b/vidyut-prakriya/src/tripadi/pada_8_2.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::args::Agama as A;
 use crate::args::Aupadeshika as Au;
 use crate::args::BaseKrt as K;
@@ -16,7 +18,6 @@ use crate::dhatu_gana;
 use crate::ganapatha;
 use crate::sounds as al;
 use crate::sounds::{map, s, Map, Set, AC, HAL, IK, JHAL};
-use lazy_static::lazy_static;
 
 const YAN: Set = s(&["yaR"]);
 const CU: Set = s(&["cu~"]);
@@ -25,11 +26,9 @@ const BASH: Set = s(&["baS"]);
 const JHAL_TO_JASH_EXCEPTIONS: Set = Set::from("cSsh");
 const HASH: Set = s(&["haS"]);
 
-lazy_static! {
-    static ref BASH_TO_BHAZ: Map = map("baS", "Baz");
-    static ref JHAL_TO_JASH: Map = map("Jal", "jaS");
-    static ref CU_TO_KU: Map = map("cu~", "ku~");
-}
+static BASH_TO_BHAZ: LazyLock<Map> = LazyLock::new(|| map("baS", "Baz"));
+static JHAL_TO_JASH: LazyLock<Map> = LazyLock::new(|| map("Jal", "jaS"));
+static CU_TO_KU: LazyLock<Map> = LazyLock::new(|| map("cu~", "ku~"));
 
 fn do_ru_adesha(rule: impl Into<Rule>, p: &mut Prakriya, i: usize) {
     p.run_at(rule, i, |t| {

--- a/vidyut-prakriya/src/tripadi/pada_8_4.rs
+++ b/vidyut-prakriya/src/tripadi/pada_8_4.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use crate::args::Aupadeshika as Au;
 use crate::args::Gana;
 use crate::args::Lakara::*;
@@ -10,7 +12,6 @@ use crate::core::Rule::Varttika;
 use crate::core::{Prakriya, Rule, Tag as T, Term};
 use crate::sounds as al;
 use crate::sounds::{map, s, Map, Set, AC, HAL, JHAL};
-use lazy_static::lazy_static;
 
 const AT_KU_PU_M: Set = s(&["aw", "ku~", "pu~", "M"]);
 const AA: Set = s(&["a"]);
@@ -27,11 +28,9 @@ const YAY: Set = s(&["yay"]);
 const JHAY: Set = s(&["Jay"]);
 const AT: Set = s(&["aw"]);
 
-lazy_static! {
-    static ref JHAL_TO_CAR: Map = map("Jal", "car");
-    static ref JHAL_TO_JASH: Map = map("Jal", "jaS");
-    static ref JHAL_TO_JASH_CAR: Map = map("Jal", "jaS car");
-}
+static JHAL_TO_CAR: LazyLock<Map> = LazyLock::new(|| map("Jal", "car"));
+static JHAL_TO_JASH: LazyLock<Map> = LazyLock::new(|| map("Jal", "jaS"));
+static JHAL_TO_JASH_CAR: LazyLock<Map> = LazyLock::new(|| map("Jal", "jaS car"));
 
 /// Runs rules that change `n` to `R`.
 /// Example: krInAti -> krIRAti.

--- a/vidyut-prakriya/tests/integration/kashika_1_1.rs
+++ b/vidyut-prakriya/tests/integration/kashika_1_1.rs
@@ -1,5 +1,6 @@
 extern crate test_utils;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use test_utils::*;
 use vidyut_prakriya::args::BaseKrt as Krt;
 use vidyut_prakriya::args::Gana::*;
@@ -10,9 +11,7 @@ use vidyut_prakriya::args::Taddhita as T;
 use vidyut_prakriya::args::TaddhitaArtha::*;
 use vidyut_prakriya::args::Unadi;
 
-lazy_static! {
-    static ref S: Tester = Tester::with_svara_rules();
-}
+static S: LazyLock<Tester> = LazyLock::new(|| Tester::with_svara_rules());
 
 #[test]
 fn sutra_1_1_1() {

--- a/vidyut-prakriya/tests/integration/kashika_3_1.rs
+++ b/vidyut-prakriya/tests/integration/kashika_3_1.rs
@@ -1,5 +1,6 @@
 extern crate test_utils;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use test_utils::*;
 use vidyut_prakriya::args::BaseKrt as Krt;
 use vidyut_prakriya::args::Gana::*;
@@ -9,9 +10,7 @@ use vidyut_prakriya::args::Taddhita as T;
 use vidyut_prakriya::args::TaddhitaArtha as TA;
 use vidyut_prakriya::args::*;
 
-lazy_static! {
-    static ref S: Tester = Tester::with_svara_rules();
-}
+static S: LazyLock<Tester> = LazyLock::new(|| Tester::with_svara_rules());
 
 fn sanadi(p: Pratipadika, s: Sanadi) -> Dhatu {
     Dhatu::nama(p, Some(s))

--- a/vidyut-prakriya/tests/integration/kashika_6_1.rs
+++ b/vidyut-prakriya/tests/integration/kashika_6_1.rs
@@ -1,5 +1,6 @@
 extern crate test_utils;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use test_utils::*;
 use vidyut_prakriya::args::BaseKrt as Krt;
 use vidyut_prakriya::args::Gana::*;
@@ -9,9 +10,7 @@ use vidyut_prakriya::args::Taddhita as T;
 use vidyut_prakriya::args::TaddhitaArtha::*;
 use vidyut_prakriya::args::*;
 
-lazy_static! {
-    static ref S: Tester = Tester::with_svara_rules();
-}
+static S: LazyLock<Tester> = LazyLock::new(|| Tester::with_svara_rules());
 
 #[test]
 fn sutra_6_1_1() {

--- a/vidyut-prakriya/tests/integration/kashika_6_2.rs
+++ b/vidyut-prakriya/tests/integration/kashika_6_2.rs
@@ -1,10 +1,9 @@
 extern crate test_utils;
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use test_utils::*;
 
-lazy_static! {
-    static ref S: Tester = Tester::with_svara_rules();
-}
+static S: LazyLock<Tester> = LazyLock::new(|| Tester::with_svara_rules());
 
 #[test]
 fn sutra_6_2_27() {

--- a/vidyut-sandhi/Cargo.toml
+++ b/vidyut-sandhi/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 clap = { version = "4.0.12", features = ["derive"] }
 compact_str = "0.7.1"
 csv = "1.1.6"
-lazy_static = "1.4.0"
 rustc-hash = "2.1.0"
 
 [dev-dependencies]

--- a/vidyut-sandhi/src/generator.rs
+++ b/vidyut-sandhi/src/generator.rs
@@ -3,8 +3,9 @@ Utilities for generating sandhi rules.
 
 For details, see the `create_rules` function below.
 */
+use std::sync::LazyLock;
+
 use crate::sounds::Set;
-use lazy_static::lazy_static;
 
 /// All vowels.
 const AC: &str = "aAiIuUfFxXeEoO";
@@ -63,17 +64,13 @@ fn is_savarna_ac(f: char, s: char) -> bool {
 
 /// Returns whether the given sound is voiced.
 fn is_ghoshavat(c: char) -> bool {
-    lazy_static! {
-        static ref S: Set = Set::from(r"aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh");
-    }
+    static S: LazyLock<Set> = LazyLock::new(|| Set::from(r"aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh"));
     S.contains(c)
 }
 
 /// Returns whether the given sound is nasal.
 fn is_anunasika(c: char) -> bool {
-    lazy_static! {
-        static ref S: Set = Set::from(r"NYRnm");
-    }
+    static S: LazyLock<Set> = LazyLock::new(|| Set::from(r"NYRnm"));
     S.contains(c)
 }
 

--- a/vidyut-sandhi/src/sounds.rs
+++ b/vidyut-sandhi/src/sounds.rs
@@ -1,6 +1,6 @@
 //! Utility functions for checking Sanskrit sounds.
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 /// A set of Sanskrit sounds.
 ///
@@ -43,9 +43,8 @@ impl Default for Set {
 /// - other punctuation characters (|, ||, numbers)
 /// - characters or symbols from non-SLP1 encodings
 pub fn is_sanskrit(c: char) -> bool {
-    lazy_static! {
-        static ref CHARS: Set = Set::from("aAiIuUfFxXeEoOMHkKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL'");
-    }
+    static CHARS: LazyLock<Set> =
+        LazyLock::new(|| Set::from("aAiIuUfFxXeEoOMHkKgGNcCjJYwWqQRtTdDnpPbBmyrlvSzshL'"));
     CHARS.contains(c)
 }
 
@@ -54,18 +53,15 @@ pub fn is_sanskrit(c: char) -> bool {
 /// `ac` is the Paninian name for the Sanskrit vowels.
 #[allow(dead_code)]
 pub fn is_ac(c: char) -> bool {
-    lazy_static! {
-        static ref AC: Set = Set::from("aAiIuUfFxXeEoO");
-    }
+    static AC: LazyLock<Set> = LazyLock::new(|| Set::from("aAiIuUfFxXeEoO"));
     AC.contains(c)
 }
 
 /// Returns whether the given sound is voiced.
 #[allow(dead_code)]
 pub fn is_ghosha(c: char) -> bool {
-    lazy_static! {
-        static ref GHOSHA: Set = Set::from("aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh");
-    }
+    static GHOSHA: LazyLock<Set> =
+        LazyLock::new(|| Set::from("aAiIuUfFxXeEoOgGNjJYqQRdDnbBmyrlvh"));
     GHOSHA.contains(c)
 }
 

--- a/vidyut-sandhi/src/splitter.rs
+++ b/vidyut-sandhi/src/splitter.rs
@@ -17,11 +17,11 @@ use crate::errors::Result;
 use crate::sounds;
 use crate::sounds::Set;
 use compact_str::CompactString;
-use lazy_static::lazy_static;
 use rustc_hash::FxHashMap;
 use std::cmp;
 use std::collections::hash_map::Keys;
 use std::path::Path;
+use std::sync::LazyLock;
 
 /// Describes the type of sandhi split that occurred.
 #[derive(Copy, Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
@@ -331,14 +331,14 @@ fn visarga_to_r(s: &str) -> CompactString {
 }
 
 /// Returns whether the first item in a sandhi split is OK according to some basic heuristics.
+#[allow(dead_code)]
 fn is_good_first(text: &str) -> bool {
-    lazy_static! {
-        static ref AC: Set = Set::from("aAiIuUfFxXeEoO");
-        static ref SPARSHA: Set = Set::from("kKgGNcCjJYwWqQRtTdDnpPbBm");
-        static ref HAL: Set = Set::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvzSsh");
-        // Vowels, standard consonants, and "s" and "r"
-        static ref VALID_FINALS: Set = Set::from("aAiIuUfFxXeEoOHkNwRtpnmsr");
-    }
+    static AC: LazyLock<Set> = LazyLock::new(|| Set::from("aAiIuUfFxXeEoO"));
+    static SPARSHA: LazyLock<Set> = LazyLock::new(|| Set::from("kKgGNcCjJYwWqQRtTdDnpPbBm"));
+    static HAL: LazyLock<Set> = LazyLock::new(|| Set::from("kKgGNcCjJYwWqQRtTdDnpPbBmyrlvzSsh"));
+    // Vowels, standard consonants, and "s" and "r"
+    static VALID_FINALS: LazyLock<Set> = LazyLock::new(|| Set::from("aAiIuUfFxXeEoOHkNwRtpnmsr"));
+
     let mut chars = text.chars().rev();
     if let (Some(y), Some(x)) = (chars.next(), chars.next()) {
         if (AC.contains(x) && AC.contains(y)) || (HAL.contains(x) && HAL.contains(y)) {
@@ -353,11 +353,10 @@ fn is_good_first(text: &str) -> bool {
 
 /// Returns whether the second item in a sandhi split is OK according to some basic heuristics.
 fn is_good_second(text: &str) -> bool {
-    lazy_static! {
-        static ref YAN: Set = Set::from("yrlv");
-        static ref AC: Set = Set::from("aAiIuUfFxXeEoO");
-        static ref SPARSHA: Set = Set::from("kKgGNcCjJYwWqQRtTdDnpPbBm");
-    }
+    static YAN: LazyLock<Set> = LazyLock::new(|| Set::from("yrlv"));
+    static AC: LazyLock<Set> = LazyLock::new(|| Set::from("aAiIuUfFxXeEoO"));
+    static SPARSHA: LazyLock<Set> = LazyLock::new(|| Set::from("kKgGNcCjJYwWqQRtTdDnpPbBm"));
+
     let mut chars = text.chars();
     if let (Some(x), Some(y)) = (chars.next(), chars.next()) {
         if AC.contains(x) && AC.contains(y) {


### PR DESCRIPTION
* Latest iteration of Rust since 1.71 can perform LazyLock which is what lazy_static was used for
* Use standard library instead of another crate