### PR TITLE
Fix Chandas Rules to incorrect logs for verse Type while proofReading

### DIFF
--- a/vidyut-chandas/src/akshara.rs
+++ b/vidyut-chandas/src/akshara.rs
@@ -140,6 +140,7 @@ pub fn scan_lines<'a>(lines: impl Iterator<Item = &'a str>) -> Vec<Vec<Akshara>>
         // If the first sound of the next line is heavy and in contact with this line, make the
         // last akshara of `scan` heavy.
         if let Some(next) = clean_lines.get(i + 1) {
+            let line = line.trim_end_matches('-');
             let touches_next = line.ends_with(is_sanskrit) && next.starts_with(is_sanskrit);
             if touches_next
                 && (sounds::is_samyogadi(next)
@@ -256,6 +257,11 @@ mod tests {
 
         // Last syllable of `ASramezu` becomes guru due to following samyoga.
         let scan = scan_lines("ASramezu\nsnigDa".lines());
+        assert_eq!(weights(&scan[0]), vec![G, L, G, G]);
+
+        // Trailing hyphen (line-continuation marker) is ignored:
+        // last syllable becomes guru.
+        let scan = scan_lines("ASramezu-\nsnigDa".lines());
         assert_eq!(weights(&scan[0]), vec![G, L, G, G]);
 
         // Last syllable of `ASramezu` stays laghu.

--- a/vidyut-chandas/src/padya.rs
+++ b/vidyut-chandas/src/padya.rs
@@ -202,11 +202,12 @@ impl Vrtta {
         }
 
         debug_assert_eq!(full.len(), 4);
-        if let Some(last) = full[1].last_mut() {
-            *last = Any;
-        }
-        if let Some(last) = full[3].last_mut() {
-            *last = Any;
+
+        // लघोः पदान्ते वर्तमानस्य गुरुसंज्ञाऽतिदिश्यते ( गन्ते | पि.सूत्र १.१० ) ॥
+        for pada in full.iter_mut() {
+            if let Some(last) = pada.last_mut() {
+                *last = Any;
+            }
         }
 
         let pattern_flat: Vec<VrttaWeight> = full.iter().flat_map(|x| x.to_owned()).collect();


### PR DESCRIPTION
Currently, only 2,4 paadas are treated as guru even when they are Laghu. But this can be extended to all paadas ( see Pingala Chandas Sutra 1.10 ). This is very common in literature to consider the last akshara as guru ( not only even paadas ). 

While proofreading, I found that many verses are incorrectly logged because of this behaviour. For reference see some initial verses of Champu ramayana, kumarasambhavam etc

Also, ignore `-` in the text which is making the identification as laghu because of its presence