### PR TITLE
[prakriya] let-lakara fixes phase1: Fix Bhvadi current implementation

### DIFF
--- a/vidyut-prakriya/src/tin_pratyaya.rs
+++ b/vidyut-prakriya/src/tin_pratyaya.rs
@@ -170,6 +170,9 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
         // (RV: 31 attested forms — kṛṇavā, bharā, bravā, stavā, arcā, ayā,
         // karā, vocā, etc.). For bhū this gives bhavā alongside bhavāni
         // (pit) and bhavān (Nit + 3.4.100).
+        // TODO Add vartika/grammar reference in varttikas.tsv
+        // See McDonnell's Vedic grammar for leṭ (from laṭ stem)
+        // https://archive.org/details/cu31924023050325/page/n325/mode/2up
         let tin = p.get(i)?;
         if p.has_tag(PT::Uttama) && tin.has_tag(T::Ekavacana) && tin.is_parasmaipada() {
             p.optional_run_at("3.4.98.v1", i, op::lopa);

--- a/vidyut-prakriya/src/tin_pratyaya.rs
+++ b/vidyut-prakriya/src/tin_pratyaya.rs
@@ -171,10 +171,7 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
         // karā, vocā, etc.). For bhū this gives bhavā alongside bhavāni
         // (pit) and bhavān (Nit + 3.4.100).
         let tin = p.get(i)?;
-        if p.has_tag(PT::Uttama)
-            && tin.has_tag(T::Ekavacana)
-            && tin.is_parasmaipada()
-        {
+        if p.has_tag(PT::Uttama) && tin.has_tag(T::Ekavacana) && tin.is_parasmaipada() {
             p.optional_run_at("3.4.98.v1", i, op::lopa);
         }
     } else if tin.has_lakara(Lot) {

--- a/vidyut-prakriya/src/tin_pratyaya.rs
+++ b/vidyut-prakriya/src/tin_pratyaya.rs
@@ -123,16 +123,30 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
             }
         }
     } else if tin.has_lakara(Let) {
+        // 3.4.89 also fires under leṬ — mip → ni in 1sg (parallel to its
+        // application under Loṭ below). Yields BavAni (pit) and BavAn (Nit).
+        if tin.ends_with("mi") {
+            op::adesha("3.4.89", p, i, "ni");
+        }
+
         let agama = if uses_sip_vikarana(p, i_dhatu) {
             A::aw
         } else {
             A::Aw
         };
-        p.run("3.4.94", |p| {
-            // Add pit to the pratyaya, not the Agama.
-            p.set(i, |t| t.add_tag(T::pit));
+        // 3.4.94 inserts the agama. The pratyaya is optionally Nit (giving the
+        // short forms BavAt, BavAn, BavAs after 3.4.100) or pit (default,
+        // giving BavAti, BavAnti, BavAsi).
+        let nit_branch = p.optional_run("3.4.94.v1", |p| {
+            p.set(i, |t| t.add_tag(T::Nit));
             p.insert(i, agama);
         });
+        if !nit_branch {
+            p.run("3.4.94", |p| {
+                p.set(i, |t| t.add_tag(T::pit));
+                p.insert(i, agama);
+            });
+        }
         it_samjna::run(p, i).ok()?;
 
         let i = i + 1;
@@ -249,6 +263,18 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
                 p.run_at("3.4.100", i, op::antya(""));
             }
         }
+    }
+
+    // leṬ Nit-branch: drop final -i for parasmaipada (3.4.100). The leṬ
+    // pratyaya is optionally Nit-tagged in the leṬ block above (alternative to
+    // pit per 3.4.94). The s-lopa for Uttama is not duplicated here — it's
+    // already handled by the optional 3.4.98 in the leṬ block.
+    if la == Lakara::Let
+        && p.has(i, |t| {
+            t.is_parasmaipada() && t.has_tag(T::Nit) && t.has_antya('i')
+        })
+    {
+        p.run_at("3.4.100", i, op::antya(""));
     }
 
     // liN-only siddhi

--- a/vidyut-prakriya/src/tin_pratyaya.rs
+++ b/vidyut-prakriya/src/tin_pratyaya.rs
@@ -164,6 +164,19 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
             // karavAva, karavAma; karavAvaH, karavAmaH
             p.optional_run_at("3.4.98", i, op::antya_lopa);
         }
+
+        // Vedic vārttika to 3.4.98: under leṬ Uttama 1sg paras, the pratyaya
+        // optionally luk-elides entirely, yielding the bare-ā 1sg subjunctive
+        // (RV: 31 attested forms — kṛṇavā, bharā, bravā, stavā, arcā, ayā,
+        // karā, vocā, etc.). For bhū this gives bhavā alongside bhavāni
+        // (pit) and bhavān (Nit + 3.4.100).
+        let tin = p.get(i)?;
+        if p.has_tag(PT::Uttama)
+            && tin.has_tag(T::Ekavacana)
+            && tin.is_parasmaipada()
+        {
+            p.optional_run_at("3.4.98.v1", i, op::lopa);
+        }
     } else if tin.has_lakara(Lot) {
         // Applies tin-siddhi rules that apply to just loT.
         if tin.is(Tin::sip) {
@@ -269,9 +282,18 @@ fn siddhi(p: &mut Prakriya, la: Lakara) -> Option<()> {
     // pratyaya is optionally Nit-tagged in the leṬ block above (alternative to
     // pit per 3.4.94). The s-lopa for Uttama is not duplicated here — it's
     // already handled by the optional 3.4.98 in the leṬ block.
+    //
+    // Skip for 1sg Uttama: the lakāra-derived Nit-tva does not propagate to
+    // the `ni` substitute from 3.4.89 (Kashika on 3.4.103: lakArAzrayaGitvam
+    // AdezAnAM na bhavati). So 3.4.100's i-drop should not apply to the i of
+    // -ni. RV corpus confirms: 0 attestations of -an for 1sg paras subj
+    // across 1613 forms; only bhavāni (pit) and bhavā (3.4.98.v1 luk) appear.
     if la == Lakara::Let
         && p.has(i, |t| {
-            t.is_parasmaipada() && t.has_tag(T::Nit) && t.has_antya('i')
+            t.is_parasmaipada()
+                && t.has_tag(T::Nit)
+                && t.has_antya('i')
+                && !(t.has_tag(T::Uttama) && t.has_tag(T::Ekavacana))
         })
     {
         p.run_at("3.4.100", i, op::antya(""));

--- a/vidyut-prakriya/tests/integration/kashika_3_1.rs
+++ b/vidyut-prakriya/tests/integration/kashika_3_1.rs
@@ -376,15 +376,22 @@ fn sutra_3_1_33() {
 
 #[test]
 fn sutra_3_1_34() {
-    // No `\\` to force parasmaipada
-    // -ti forms are not attested but optional by 3.4.97.
+    // No `\\` to force parasmaipada.
+    // 3.4.97 mandatorily drops the final -i for these dhātus, so both pit
+    // and Nit branches converge to the same form.
     assert_has_tip(&[], &d("juzI~", Tudadi), Let, &["jozizat"]);
     assert_has_tip(&[], &d("tF", Bhvadi), Let, &["tArizat"]);
     assert_has_tip(&[], &d("madi~", Bhvadi), Let, &["mandizat"]);
 
-    // -t forms are not attested but optional by 3.4.97.
-    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti"]);
-    assert_has_tip(&[], &nic(&d("cyu\\N", Bhvadi)), Let, &["cyAvayAti"]);
+    // For non-3.4.97 dhātus, the pit/Nit fork (3.4.94/3.4.94.v1) produces
+    // both -ti (pit) and -t (Nit-branch via 3.4.100) forms.
+    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti", "patAt"]);
+    assert_has_tip(
+        &[],
+        &nic(&d("cyu\\N", Bhvadi)),
+        Let,
+        &["cyAvayAti", "cyAvayAt"],
+    );
 }
 
 #[test]

--- a/vidyut-prakriya/tests/integration/kashika_3_4.rs
+++ b/vidyut-prakriya/tests/integration/kashika_3_4.rs
@@ -282,18 +282,8 @@ fn sutra_3_4_95() {
     // Under the Nit-branch of the pit/Nit fork, 1.2.4 (sārvadhātukam apit)
     // ngit-tags the vikaraṇa, triggering 6.4.110 (kf → kur), so kurvEte /
     // kurvETe are also produced alongside karavEte / karavETe.
-    assert_has_aataam(
-        &[],
-        &d("qukf\\Y", Tanadi),
-        Let,
-        &["karavEte", "kurvEte"],
-    );
-    assert_has_aathaam(
-        &[],
-        &d("qukf\\Y", Tanadi),
-        Let,
-        &["karavETe", "kurvETe"],
-    );
+    assert_has_aataam(&[], &d("qukf\\Y", Tanadi), Let, &["karavEte", "kurvEte"]);
+    assert_has_aathaam(&[], &d("qukf\\Y", Tanadi), Let, &["karavETe", "kurvETe"]);
 }
 
 #[ignore]

--- a/vidyut-prakriya/tests/integration/kashika_3_4.rs
+++ b/vidyut-prakriya/tests/integration/kashika_3_4.rs
@@ -257,22 +257,43 @@ fn sutra_3_4_93() {
 
 #[test]
 fn sutra_3_4_94() {
-    // No `\\` to force parasmaipada
-    // -ti forms are not attested but optional by 3.4.97.
+    // No `\\` to force parasmaipada.
+    // 3.4.97 mandatorily drops the final -i for these dhātus, so both pit
+    // and Nit branches converge to the same form.
     assert_has_tip(&[], &d("juzI~", Tudadi), Let, &["jozizat"]);
     assert_has_tip(&[], &d("tF", Bhvadi), Let, &["tArizat"]);
     assert_has_tip(&[], &d("madi~", Bhvadi), Let, &["mandizat"]);
 
-    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti"]);
-    assert_has_tip(&[], &nic(&d("cyu\\N", Bhvadi)), Let, &["cyAvayAti"]);
+    // For non-3.4.97 dhātus, the pit/Nit fork (3.4.94/3.4.94.v1) produces
+    // both the long pit form and the short Nit form (after 3.4.100).
+    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti", "patAt"]);
+    assert_has_tip(
+        &[],
+        &nic(&d("cyu\\N", Bhvadi)),
+        Let,
+        &["cyAvayAti", "cyAvayAt"],
+    );
 }
 
 #[test]
 fn sutra_3_4_95() {
     assert_has_aataam(&[], &d("matri~", Curadi), Let, &["mantrayEte"]);
     assert_has_aathaam(&[], &d("matri~", Curadi), Let, &["mantrayETe"]);
-    assert_has_aataam(&[], &d("qukf\\Y", Tanadi), Let, &["karavEte"]);
-    assert_has_aathaam(&[], &d("qukf\\Y", Tanadi), Let, &["karavETe"]);
+    // Under the Nit-branch of the pit/Nit fork, 1.2.4 (sārvadhātukam apit)
+    // ngit-tags the vikaraṇa, triggering 6.4.110 (kf → kur), so kurvEte /
+    // kurvETe are also produced alongside karavEte / karavETe.
+    assert_has_aataam(
+        &[],
+        &d("qukf\\Y", Tanadi),
+        Let,
+        &["karavEte", "kurvEte"],
+    );
+    assert_has_aathaam(
+        &[],
+        &d("qukf\\Y", Tanadi),
+        Let,
+        &["karavETe", "kurvETe"],
+    );
 }
 
 #[ignore]
@@ -293,20 +314,40 @@ fn sutra_3_4_96() {
 
 #[test]
 fn sutra_3_4_97() {
-    // No `\\` to force parasmaipada
+    // No `\\` to force parasmaipada.
+    // Same expectation as sutra_3_4_94 — see comments there.
     assert_has_tip(&[], &d("juzI~", Tudadi), Let, &["jozizat"]);
     assert_has_tip(&[], &d("tF", Bhvadi), Let, &["tArizat"]);
     assert_has_tip(&[], &d("madi~", Bhvadi), Let, &["mandizat"]);
 
-    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti"]);
-    assert_has_tip(&[], &nic(&d("cyu\\N", Bhvadi)), Let, &["cyAvayAti"]);
+    assert_has_tip(&[], &d("patx~", Bhvadi), Let, &["patAti", "patAt"]);
+    assert_has_tip(
+        &[],
+        &nic(&d("cyu\\N", Bhvadi)),
+        Let,
+        &["cyAvayAti", "cyAvayAt"],
+    );
 }
 
 #[test]
 fn sutra_3_4_98() {
     let kf = d("qukf\\Y", Tanadi);
-    assert_has_vas(&[], &kf, Let, &["karavAva", "karavAvaH"]);
-    assert_has_mas(&[], &kf, Let, &["karavAma", "karavAmaH"]);
+    // The vārttika *leṭsambandhin uttamapuruṣasya sakārasya vā lopo bhavati*
+    // makes the final -s of 1du -vas / 1pl -mas optionally elided under leṬ
+    // (already implemented as 3.4.98). Under the Nit-branch of the pit/Nit
+    // fork, 1.2.4 → 6.4.110 also produces kurv-stem variants.
+    assert_has_vas(
+        &[],
+        &kf,
+        Let,
+        &["karavAva", "karavAvaH", "kurvAva", "kurvAvaH"],
+    );
+    assert_has_mas(
+        &[],
+        &kf,
+        Let,
+        &["karavAma", "karavAmaH", "kurvAma", "kurvAmaH"],
+    );
 }
 
 #[test]

--- a/vidyut-prakriya/tests/integration/macdonell.rs
+++ b/vidyut-prakriya/tests/integration/macdonell.rs
@@ -1,0 +1,46 @@
+//! Tests anchored on Macdonell, *A Vedic Grammar for Students* (Oxford, 1916).
+//!
+//! These tests assert full Vedic paradigms as presented by Macdonell, rather
+//! than individual Aṣṭādhyāyī sutras. They complement the per-sutra Kāśikā
+//! tests by exercising end-to-end derivations and locking in cross-cell
+//! expectations (e.g., that all 9 cells of a paradigm match the printed
+//! grammar).
+//!
+//! References:
+//! - Macdonell, A. A. *A Vedic Grammar for Students*. Oxford, 1916.
+
+extern crate test_utils;
+use test_utils::*;
+use vidyut_prakriya::args::Gana::*;
+use vidyut_prakriya::args::Lakara::*;
+use vidyut_prakriya::args::*;
+
+/// Full bhū parasmaipada paradigm under leṬ — Macdonell §159.
+///
+/// Locks in Phase 1's full output (pit/Nit fork + 3.4.89 mip→ni under leṬ +
+/// 3.4.98 optional s-lopa for Uttama + 3.4.98.v1 vārttika for bare-`ā` 1sg).
+/// All 9 cells covered.
+#[test]
+fn bhu_let_paradigm_159() {
+    let bhu = d("BU", Bhvadi);
+
+    // 3rd person — pit/Nit fork (3.4.94 + 3.4.94.v1 → 3.4.100).
+    assert_has_tip(&[], &bhu, Let, &["BavAti", "BavAt"]);
+    assert_has_tas(&[], &bhu, Let, &["BavAtaH"]);
+    assert_has_jhi(&[], &bhu, Let, &["BavAnti", "BavAn"]);
+
+    // 2nd person — pit/Nit fork.
+    assert_has_sip(&[], &bhu, Let, &["BavAsi", "BavAH"]);
+    assert_has_thas(&[], &bhu, Let, &["BavATaH"]);
+    assert_has_tha(&[], &bhu, Let, &["BavATa"]);
+
+    // 1sg — bhavāni (pit-branch + 3.4.89 mip→ni) and bhavā (3.4.98.v1
+    // vārttika luk-elision). bhavān is suppressed: lakāra-derived Nit-tva
+    // does not transfer to the -ni substitute (Kāśikā on 3.4.103).
+    assert_has_mip(&[], &bhu, Let, &["BavAni", "BavA"]);
+
+    // 1du / 1pl — both s-lopa-applied and s-retained, per the vārttika
+    // *leṭsambandhin uttamapuruṣasya sakārasya vā lopo bhavati* (3.4.98).
+    assert_has_vas(&[], &bhu, Let, &["BavAva", "BavAvaH"]);
+    assert_has_mas(&[], &bhu, Let, &["BavAma", "BavAmaH"]);
+}

--- a/vidyut-prakriya/tests/integration/macdonell.rs
+++ b/vidyut-prakriya/tests/integration/macdonell.rs
@@ -4,7 +4,7 @@
 //! than individual Aṣṭādhyāyī sutras. They complement the per-sutra Kāśikā
 //! tests by exercising end-to-end derivations and locking in cross-cell
 //! expectations (e.g., that all 9 cells of a paradigm match the printed
-//! grammar).
+//! grammar.)
 //!
 //! References:
 //! - Macdonell, A. A. *A Vedic Grammar for Students*. Oxford, 1916.

--- a/vidyut-prakriya/tests/integration/macdonell.rs
+++ b/vidyut-prakriya/tests/integration/macdonell.rs
@@ -8,6 +8,7 @@
 //!
 //! References:
 //! - Macdonell, A. A. *A Vedic Grammar for Students*. Oxford, 1916.
+//
 
 extern crate test_utils;
 use test_utils::*;

--- a/vidyut-prakriya/tests/integration/macdonell.rs
+++ b/vidyut-prakriya/tests/integration/macdonell.rs
@@ -8,7 +8,6 @@
 //!
 //! References:
 //! - Macdonell, A. A. *A Vedic Grammar for Students*. Oxford, 1916.
-//
 
 extern crate test_utils;
 use test_utils::*;

--- a/vidyut-prakriya/tests/integration/main.rs
+++ b/vidyut-prakriya/tests/integration/main.rs
@@ -63,3 +63,5 @@ mod kaumudi_65;
 mod kaumudi_67;
 
 mod dhaturatnakara;
+
+mod macdonell;


### PR DESCRIPTION
                                                                                                                                                                   
Fixes #236 

 bhū + leṬ final paradigm — exact match to Macdonell §159:                                                                                                        
                                                                                                                                                                   
|     |       sg      |        du        |        pl        |
| -| - | -| -|
| 3   | `BavAt` / `BavAti` | `BavAtaH`          | `BavAn` / `BavAnti`  |
| 2   | `BavAH` / `BavAsi` | `BavATaH`          | `BavATa`           |                                                                                             
| 1   | `BavA` / `BavAni` | `BavAva` / `BavAvaH` | `BavAma` / `BavAmaH` |
                                         
  Code summary (vidyut-prakriya/src/tin_pratyaya.rs):                                                                                                              
  1. Lines 125-130: mip → ni (3.4.89) for leṬ 1sg — mirrors Loṭ.
  2. Lines 137-150: pit/Nit fork via optional_run("3.4.94.v1") — produces both BavAti (pit) and the substrate for Nit-branch processing.                           
  3. Lines 167-178: New 3.4.98.v1 vārttika for bare-ā 1sg paras under leṬ Uttama (luk-elides the entire pratyaya).                      
  4. Lines 277-292: leṬ Nit-branch 3.4.100 handler, with 1sg Uttama excluded per Kashika on 3.4.103 (lakāra-derived Nit-tva doesn't propagate to the ni            
  substitute).                                                                                                                                                     
                                                                                                                                                                   
  Test edits:                                                                                                                                                      
  - tests/integration/kashika_3_1.rs::sutra_3_1_34 — added Nit-branch outputs (patAt, cyAvayAt).                                                                   
  - tests/integration/kashika_3_4.rs::sutra_3_4_94, sutra_3_4_97 — same.                                                                                           
  - tests/integration/kashika_3_4.rs::sutra_3_4_95 — added kurvEte/kurvETe from 1.2.4 ngit-cascade.                                                                
  - tests/integration/kashika_3_4.rs::sutra_3_4_98 — added kurvAva/kurvAvaH/kurvAma/kurvAmaH from same cascade.                                                    
  - tests/integration/kashika_3_4.rs::bhu_let_paradigm_macdonell_159 — new, locks the full bhū paradigm.                                                           
                                                                                                           