### PR TITLE
[prakriya] Fix kramu + Satf with parasmaipadi samjna

### DIFF
--- a/vidyut-prakriya/src/krt/basic.rs
+++ b/vidyut-prakriya/src/krt/basic.rs
@@ -1431,6 +1431,11 @@ fn try_add_krt(kp: &mut KrtPrakriya) -> Option<bool> {
                     };
                     kp.try_replace_lakara(rule, i_la, krt);
                 }
+                if krt == K::kvasu {
+                    kp.p.add_tag_at("1.4.99", i_la, T::Parasmaipada);
+                } else {
+                    kp.p.add_tag_at("1.4.100", i_la, T::Atmanepada);
+                }
             }
         }
 
@@ -1469,6 +1474,11 @@ fn try_add_krt(kp: &mut KrtPrakriya) -> Option<bool> {
                 }
                 if kp.has_krt {
                     kp.p.add_tag_at("3.2.127", i_la, T::Sat);
+                    if krt == K::Satf {
+                        kp.p.add_tag_at("1.4.99", i_la, T::Parasmaipada);
+                    } else {
+                        kp.p.add_tag_at("1.4.100", i_la, T::Atmanepada);
+                    }
                 }
             }
         }


### PR DESCRIPTION
1.  As per 1.4.99
    1. `क्रमुँ + शतृ` should have upadha dirgha `क्रामत्` as in `उत्क्रामन्तं` स्थितं वापि
    2. kvasu should have parasmaipadi
2. "SAnac and kAnac" should have atmanepadi as per 1.4.100

#### Krdantas
|Derivation for | After | Before |
|---------------|---------|-------|
| kramu~, BvAdi, 545, , Kartari, Lat, Satf | क्रामत् , क्राम्यत् | क्रमत् , क्रम्यत् |
